### PR TITLE
Fix a bug in Android 10

### DIFF
--- a/app/src/main/java/fuck/location/xposed/helpers/ConfigGateway.kt
+++ b/app/src/main/java/fuck/location/xposed/helpers/ConfigGateway.kt
@@ -333,12 +333,12 @@ class ConfigGateway private constructor() {
     fun callerIdentityToPackageName(callerIdentity: Any): String {
         val fields = HiddenApiBypass.getInstanceFields(callerIdentity.javaClass)
 
-        lateinit var targetFieldName: String
-        when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> targetFieldName = "private final java.lang.String android.location.util.identity.CallerIdentity.mPackageName"
-            Build.VERSION.SDK_INT == Build.VERSION_CODES.R -> targetFieldName = "public final java.lang.String com.android.server.location.CallerIdentity.packageName"
-            Build.VERSION.SDK_INT == Build.VERSION_CODES.Q -> targetFieldName = "public final java.lang.String com.android.server.location.CallerIdentity.mPackageName"
-            Build.VERSION.SDK_INT == Build.VERSION_CODES.P -> targetFieldName = "final java.lang.String com.android.server.LocationManagerService.Identity.mPackageName"
+        val targetFieldName = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> "private final java.lang.String android.location.util.identity.CallerIdentity.mPackageName"
+            Build.VERSION.SDK_INT == Build.VERSION_CODES.R -> "public final java.lang.String com.android.server.location.CallerIdentity.packageName"
+            Build.VERSION.SDK_INT == Build.VERSION_CODES.Q -> "public final java.lang.String com.android.server.location.CallerIdentity.mPackageName"
+            Build.VERSION.SDK_INT == Build.VERSION_CODES.P -> "final java.lang.String com.android.server.LocationManagerService.Identity.mPackageName"
+            else -> ""
         }
 
         for (field in fields) {

--- a/app/src/main/java/fuck/location/xposed/location/LocationHookerAfterS.kt
+++ b/app/src/main/java/fuck/location/xposed/location/LocationHookerAfterS.kt
@@ -186,7 +186,7 @@ class LocationHookerAfterS {
                 name == "mIdentity"
             }.get(registration.value)
 
-            val packageName = ConfigGateway.get().callerIdentityToPackageName(callerIdentity)
+            val packageName = ConfigGateway.get().callerIdentityToPackageName(callerIdentity!!)
 
             if (!ConfigGateway.get().inWhitelist(packageName)) {
                 newRegistrations[registration.key] = registration.value

--- a/app/src/main/java/fuck/location/xposed/location/LocationHookerPreQ.kt
+++ b/app/src/main/java/fuck/location/xposed/location/LocationHookerPreQ.kt
@@ -46,7 +46,7 @@ class LocationHookerPreQ {
                         location.verticalAccuracyMeters = originLocation.verticalAccuracyMeters
                     }
 
-                    location.latitude = fakeLocation?.x!!
+                    location.latitude = fakeLocation.x
                     location.longitude = fakeLocation.y
                     location.altitude = 0.0
                     location.speed = 0F
@@ -92,7 +92,7 @@ class LocationHookerPreQ {
                             name == "mCallerIdentity"
                         }.get(mReceiver)
 
-                        val packageName = ConfigGateway.get().callerIdentityToPackageName(mCallerIdentity)
+                        val packageName = ConfigGateway.get().callerIdentityToPackageName(mCallerIdentity!!)
 
                         if (!ConfigGateway.get().inWhitelist(packageName)) {
                             newValue.add(record)
@@ -102,7 +102,7 @@ class LocationHookerPreQ {
 
                             val location = Location(originLocation.provider)
 
-                            location.latitude = fakeLocation?.x!!
+                            location.latitude = fakeLocation.x
                             location.longitude = fakeLocation.y
                             location.altitude = 0.0
                             location.speed = 0F
@@ -124,7 +124,7 @@ class LocationHookerPreQ {
                             // TODO: this is a unsafe call that bypass the validation of system
                             findMethod(mReceiver.javaClass, false) {
                                 name == "callLocationChangedLocked" && isPublic
-                            }.invoke(location)
+                            }.invoke(mReceiver, location)
                         }
                     }
 

--- a/app/src/main/java/fuck/location/xposed/location/LocationHookerR.kt
+++ b/app/src/main/java/fuck/location/xposed/location/LocationHookerR.kt
@@ -49,7 +49,7 @@ class LocationHookerR {
                         location.verticalAccuracyMeters = originLocation.verticalAccuracyMeters
                     }
 
-                    location.latitude = fakeLocation?.x!!
+                    location.latitude = fakeLocation.x
                     location.longitude = fakeLocation.y
                     location.altitude = 0.0
                     location.speed = 0F
@@ -120,7 +120,7 @@ class LocationHookerR {
                         }.get(mReceiver)
 
                         val packageName =
-                            ConfigGateway.get().callerIdentityToPackageName(mCallerIdentity)
+                            ConfigGateway.get().callerIdentityToPackageName(mCallerIdentity!!)
 
                         if (!ConfigGateway.get().inWhitelist(packageName)) {
                             newValue.add(record)
@@ -132,7 +132,7 @@ class LocationHookerR {
 
                             val location = Location(originLocation.provider)
 
-                            location.latitude = fakeLocation?.x!!
+                            location.latitude = fakeLocation.x
                             location.longitude = fakeLocation.y
                             location.altitude = 0.0
                             location.speed = 0F


### PR DESCRIPTION
Forgot to pass instance parameter when calling 'callLocationChangedLocked' method.